### PR TITLE
Plugins Knex Bug Fixed 

### DIFF
--- a/src/infra/db/mssql/util/knex/extensions/date-to-string-interceptor-plugin.ts
+++ b/src/infra/db/mssql/util/knex/extensions/date-to-string-interceptor-plugin.ts
@@ -17,19 +17,29 @@ function allowConvertDateToString(date: Date) {
   return !dateValues.every((value) => value === 0);
 }
 
+function formatDateEntries([key, value]: [string, unknown]) {
+  if (value instanceof Date && allowConvertDateToString(value)) {
+    const dateToString = format(value, 'yyyy-MM-dd HH:mm:ss');
+    return [key, dateToString];
+  }
+
+  return [key, value];
+}
+
 function singleDataToStringInterceptor(data: Record<string, unknown>) {
   if (!data) return;
 
+  if (Array.isArray(data)) {
+    const entries = data.map(Object.entries);
+    const newEntries = entries.map((entriesObjects) =>
+      entriesObjects.map(formatDateEntries)
+    );
+    return newEntries.map(Object.fromEntries);
+  }
+
   const entries = Object.entries(data);
 
-  const newEntries = entries.map(([key, value]) => {
-    if (value instanceof Date && allowConvertDateToString(value)) {
-      const dateToString = format(value, 'yyyy-MM-dd HH:mm:ss');
-      return [key, dateToString];
-    }
-
-    return [key, value];
-  });
+  const newEntries = entries.map(formatDateEntries);
 
   return Object.fromEntries(newEntries);
 }

--- a/src/infra/db/mssql/util/knex/extensions/formatted-select-plugin.ts
+++ b/src/infra/db/mssql/util/knex/extensions/formatted-select-plugin.ts
@@ -62,7 +62,13 @@ function transformResponse(response: Object[] | Object) {
 function resolveWrapper(resolve: (data: Object | Object[]) => void) {
   return (data: Object | Object[]) => {
     if (!data) return data;
+
     const sample = Array.isArray(data) ? data[0] : data;
+
+    if (!sample) {
+      resolve(data);
+      return;
+    }
 
     const doesTheSelectHaveNestedObjects = Object.keys(sample).find((key) =>
       key.includes(DELIMITER)


### PR DESCRIPTION
## I'm submitting a ...

- [✔] bug report
- [✔] bug fixed

## What is the current behavior?
Currently the features which wrapper the default knex behavior was throwing exceptions when was provided a array of rows and if the insert method was called without any returing. 

## If the current behavior is a bug, please provide the steps to reproduce and if possible a minimal demo of the problem
 to reproduce the bugs you can call a simple await connection(any_table).insert(any_value) and await connection(any_table).insert(row[]);

## What is the expected behavior?

The expected behavior is to run the above knex commands without throws any exception

## What is the motivation / use case for changing the behavior?

Critical Failed, most of the queries in all of the environments will be blocked without this fixed

## Please tell us about your environment:
Language: Typescript 