### PR TITLE
Feat: add normalize only to reprocess and code improvements

### DIFF
--- a/src/data/usecases/elasticsearch/es-create-event.ts
+++ b/src/data/usecases/elasticsearch/es-create-event.ts
@@ -16,7 +16,7 @@ export class EsCreateEvent implements CreateEvent {
     const now = new Date();
     const nowToString = this.formatDate(now, 'yyyy-MM-dd HH:mm:ss');
 
-    if (!ids) throw new Error('UNABLE_TO_GET_APM_TRANSACTION_ID');
+    if (!ids) return;
 
     return this.createDocumentService.create({
       id: ids.transactionId,

--- a/src/data/usecases/elasticsearch/es-update-event.ts
+++ b/src/data/usecases/elasticsearch/es-update-event.ts
@@ -18,7 +18,7 @@ export class EsUpdateEvent implements UpdateEvent {
   async update(params: UpdateEvent.Params): UpdateEvent.Result {
     const ids = this.getAPMTransactionIds();
 
-    if (!ids) throw new Error('UNABLE_TO_GET_APM_TRANSACTION_ID');
+    if (!ids) return;
 
     const INDEX = 'datora-event';
 

--- a/src/domain/usecases/event/create-event.ts
+++ b/src/domain/usecases/event/create-event.ts
@@ -4,5 +4,5 @@ export interface CreateEvent {
 
 export namespace CreateEvent {
   export type Params = Record<string, unknown>;
-  export type Result = Promise<{ id: string }>;
+  export type Result = Promise<{ id: string } | void>;
 }

--- a/src/domain/usecases/event/update-event.ts
+++ b/src/domain/usecases/event/update-event.ts
@@ -4,5 +4,5 @@ export interface UpdateEvent {
 
 export namespace UpdateEvent {
   export type Params = Record<string, unknown>;
-  export type Result = Promise<{ id: string }>;
+  export type Result = Promise<{ id: string } | void>;
 }

--- a/src/job/utils/reprocessing.ts
+++ b/src/job/utils/reprocessing.ts
@@ -33,6 +33,7 @@ const normalizePayload = (
 type Options = {
   maxTries?: number;
   delays?: number[];
+  normalizeOnly?: boolean;
   queueOptions?: {
     exchange: string;
     routingKey?: string;
@@ -83,7 +84,7 @@ export function reprocessing(options: Options = {}) {
 
         return result;
       } catch (error) {
-        if (!REPROCESSING.ENABLED) return;
+        if (!REPROCESSING.ENABLED || options.normalizeOnly) return;
         mqSendReprocessing.reprocess({
           middleware: target.constructor.name,
           tries: state?.reprocessing?.tries,

--- a/src/main/adapters/flow-adapter.ts
+++ b/src/main/adapters/flow-adapter.ts
@@ -23,6 +23,7 @@ export default <Data extends Record<string, unknown>>(data: Data) =>
         let nextFunctionWasCalled = false;
 
         function nextFunctionDecorator() {
+          if (nextFunctionWasCalled) return;
           nextFunction();
           nextFunctionWasCalled = true;
         }

--- a/test/unit/main/adapters/flow-adapter.spec.ts
+++ b/test/unit/main/adapters/flow-adapter.spec.ts
@@ -1,0 +1,25 @@
+import makeFlow from '@/main/adapters/flow-adapter';
+
+describe('#Flow Adapter', () => {
+  it('should call next function only one time per flow iterations', async () => {
+    const arr: number[] = [];
+    const flow = makeFlow({});
+
+    await flow(
+      (_, next) => {
+        arr.push(1);
+        next();
+        next();
+        next();
+      },
+      (_, next) => {
+        arr.push(2);
+      },
+      (_, next) => {
+        arr.push(3);
+      }
+    )();
+
+    expect(arr).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
1. Add normalizeOnly option to rabbit reprocess decorator.
2. Fix flow adapter to don't call next when callback calls nextFunction more than onde time.
3. Remove throw error on Elastic event usecases.