### PR TITLE
Fix Default Method Not Working at Database migrations

### DIFF
--- a/src/@types/global.d.ts
+++ b/src/@types/global.d.ts
@@ -1,6 +1,7 @@
 export {};
 
 declare global {
+  type Nullable<T> = T | null;
   type RemoveUnderscoreFirstLetter<S extends string> =
     S extends `${infer FirstLetter}${infer U}`
       ? `${FirstLetter extends '_' ? U : `${FirstLetter}${U}`}`

--- a/src/util/db/create-mock-table.ts
+++ b/src/util/db/create-mock-table.ts
@@ -1,28 +1,18 @@
-import 'dotenv/config';
-
-import { Knex } from 'knex';
-
 import { Table, sqlConnection } from '@/infra/db/mssql/util';
 
+import 'dotenv/config';
 import { tryToRun } from '../functions';
 import {
-  StringSchema,
   BooleanSchema,
   DateSchema,
-  NumberSchema
+  NumberSchema,
+  StringSchema
 } from './types/';
-import { PermittedTypes, TypeSchema } from './types/schema';
+import { TypeSchema } from './types/schema';
 
 type StrictTypesConversion<T extends readonly string[]> = {
   [P in T[number]]: DateSchema | StringSchema | BooleanSchema | NumberSchema;
 };
-
-export const allowMethodsInKnex = (knex: Knex.CreateTableBuilder) => ({
-  string: knex.string,
-  date: knex.date,
-  number: knex.integer,
-  boolean: knex.boolean
-});
 
 export const createMockTable = async <
   T extends Table<string>,
@@ -33,33 +23,36 @@ export const createMockTable = async <
 ) => {
   if (String(process.env.NODE_ENV).toLowerCase() !== 'test')
     throw new Error('Need to be in a test environment to use this function');
+
   if (typeof table !== 'object') return;
+
   if (!table.getColumnsObject)
     throw new Error('Missing dependency getColumnsObject at table object');
-  await sqlConnection.schema.createTable(table.TABLE, (builder) => {
-    Object.entries(schema).forEach(async ([key, value]) => {
-      if (value instanceof TypeSchema) {
-        const { __type: type } = value;
 
-        switch (type as PermittedTypes) {
+  const tableExists = await sqlConnection.schema.hasTable(table.TABLE);
+
+  if (tableExists) return;
+
+  await sqlConnection.schema.createTable(table.TABLE, (builder) => {
+    Object.entries(schema).forEach(([key, value]) => {
+      if (value instanceof TypeSchema) {
+        const { getType: type } = value;
+        switch (type) {
           case 'date':
-            if (!value.__default) builder.datetime(key);
-            else
-              builder.datetime(key).defaultTo(await tryToRun(value.__default));
+            if (!value.getDefault) builder.datetime(key);
+            else builder.datetime(key).defaultTo(tryToRun(value.getDefault));
             break;
           case 'number':
-            if (!value.__default) builder.integer(key);
-            else
-              builder.integer(key).defaultTo(await tryToRun(value.__default));
+            if (!value.getDefault) builder.integer(key);
+            else builder.integer(key).defaultTo(tryToRun(value.getDefault));
             break;
           case 'boolean':
-            if (!value.__default) builder.boolean(key);
-            else
-              builder.boolean(key).defaultTo(await tryToRun(value.__default));
+            if (!value.getDefault) builder.boolean(key);
+            else builder.boolean(key).defaultTo(tryToRun(value.getDefault));
             break;
           default:
-            if (!value.__default) builder.string(key);
-            else builder.string(key).defaultTo(await tryToRun(value.__default));
+            if (!value.getDefault) builder.string(key);
+            else builder.string(key).defaultTo(tryToRun(value.getDefault));
             break;
         }
       }

--- a/src/util/db/types/boolean-schema.ts
+++ b/src/util/db/types/boolean-schema.ts
@@ -1,8 +1,8 @@
 import { TypeSchema } from './schema';
 
-type DefaultBooleanValue = (() => boolean) | boolean;
+type DefaultBooleanValue = (() => Nullable<boolean>) | Nullable<boolean>;
 
-export class BooleanSchema extends TypeSchema<'boolean', DefaultBooleanValue> {
+export class BooleanSchema extends TypeSchema {
   constructor() {
     super({
       type: 'boolean'

--- a/src/util/db/types/date-schema.ts
+++ b/src/util/db/types/date-schema.ts
@@ -1,8 +1,8 @@
 import { TypeSchema } from './schema';
 
-type DefaultDateValue = (() => Date) | Date;
+type DefaultDateValue = (() => Nullable<Date>) | Nullable<Date>;
 
-export class DateSchema extends TypeSchema<'date', DefaultDateValue> {
+export class DateSchema extends TypeSchema {
   constructor() {
     super({
       type: 'date'

--- a/src/util/db/types/number-schema.ts
+++ b/src/util/db/types/number-schema.ts
@@ -1,8 +1,8 @@
 import { TypeSchema } from './schema';
 
-type DefaultNumberValue = (() => number) | number;
+type DefaultNumberValue = (() => Nullable<number>) | Nullable<number>;
 
-export class NumberSchema extends TypeSchema<'number', DefaultNumberValue> {
+export class NumberSchema extends TypeSchema {
   constructor() {
     super({
       type: 'number'

--- a/src/util/db/types/schema.ts
+++ b/src/util/db/types/schema.ts
@@ -2,27 +2,26 @@ type Maybe<T> = T | null | undefined;
 
 export type PermittedTypes = 'string' | 'boolean' | 'number' | 'date';
 
-export interface ITypeSchema<T extends PermittedTypes, D> {
-  __type: T;
-  __default: D | undefined;
-}
+type DefaultValue = Function | (() => unknown) | unknown | null;
 
-type DefaultValue = (() => unknown) | unknown | null;
+export abstract class TypeSchema {
+  protected __default!: DefaultValue | undefined;
+  protected readonly __type!: PermittedTypes;
 
-export abstract class TypeSchema<
-  T extends PermittedTypes,
-  D extends DefaultValue
-> implements ITypeSchema<T, D>
-{
-  __default!: D | undefined;
-  readonly __type!: T;
-
-  constructor(args: { type: Maybe<T> }) {
+  constructor(args: { type: Maybe<PermittedTypes> }) {
     this.validate(args.type);
     this.__type = args.type!;
   }
 
-  public setDefault(args?: D) {
+  get getType(): PermittedTypes {
+    return this.__type;
+  }
+
+  get getDefault(): DefaultValue {
+    return this.__default;
+  }
+
+  protected setDefault(args?: DefaultValue) {
     this.__default = args;
   }
 

--- a/src/util/db/types/string-schema.ts
+++ b/src/util/db/types/string-schema.ts
@@ -1,8 +1,8 @@
 import { TypeSchema } from './schema';
 
-type DefaultStringValue = (() => string) | string;
+type DefaultStringValue = (() => Nullable<string>) | Nullable<string>;
 
-export class StringSchema extends TypeSchema<'string', DefaultStringValue> {
+export class StringSchema extends TypeSchema {
   constructor() {
     super({
       type: 'string'

--- a/src/util/functions/try-run.ts
+++ b/src/util/functions/try-run.ts
@@ -1,7 +1,10 @@
-export async function tryToRun(callback: Function | unknown) {
+type Callback = Function | (() => unknown) | unknown | null;
+
+export function tryToRun<C extends Callback, R>(
+  callback: C
+): C | R | Promise<R> | null {
   if (typeof callback !== 'function') {
     return callback;
   }
-  const result = await callback();
-  return result;
+  return callback();
 }

--- a/test/migrations/example-db.ts
+++ b/test/migrations/example-db.ts
@@ -2,6 +2,8 @@
  * @description This should be used to up and down all or part of a database!
  */
 
+import { randomUUID } from 'crypto';
+
 import { EXAMPLE_DB } from '@/infra/db/mssql/util';
 import { createMockTable, downMockTable } from '@/util/db';
 import { date, number, string } from '@/util/db/types';
@@ -15,41 +17,41 @@ export const migrate = {
   // implement migration here!
   up: {
     HealthIntegrationTest: async () => {
-      const promiseExampleTb = createMockTable(EXAMPLE, {
+      const promiseExampleTable = createMockTable(EXAMPLE, {
         created_at: date().default(() => new Date()),
         updated_at: date().default(() => new Date()),
-        deleted_at: date().default(() => new Date()),
+        deleted_at: date().default(() => null),
         description: string(),
-        external_id: string(),
+        external_id: string().default(() => randomUUID()),
         example_id: number(),
         value: number()
       });
-      const promiseFooTb = createMockTable(FOO, {
+      const promiseFooTable = createMockTable(FOO, {
         created_at: date().default(() => new Date()),
         updated_at: date().default(() => new Date()),
-        deleted_at: date().default(() => new Date()),
+        deleted_at: date().default(() => null),
         description: string(),
-        external_id: string(),
+        external_id: string().default(() => randomUUID()),
         foo_id: number(),
         example_id: number(),
         value: number()
       });
-      await Promise.all([promiseExampleTb, promiseFooTb]);
+      await Promise.all([promiseExampleTable, promiseFooTable]);
     },
     ExampleDbUnitTest: async () => {
       const promiseExampleTb = createMockTable(EXAMPLE, {
         created_at: date().default(() => new Date()),
         updated_at: date().default(() => new Date()),
-        deleted_at: date().default(() => new Date()),
+        deleted_at: date().default(() => null),
         description: string(),
-        external_id: string(),
+        external_id: string().default(() => randomUUID()),
         example_id: number(),
         value: number()
       });
       const promiseFooTb = createMockTable(FOO, {
         created_at: date().default(() => new Date()),
         updated_at: date().default(() => new Date()),
-        deleted_at: date().default(() => new Date()),
+        deleted_at: date().default(() => null),
         description: string(),
         external_id: string(),
         foo_id: number(),

--- a/test/seed/example-db-seed.ts
+++ b/test/seed/example-db-seed.ts
@@ -1,5 +1,4 @@
 import { EXAMPLE_DB, sqlConnection } from '@/infra/db/mssql/util';
-import { sumDays } from '@/util';
 
 const {
   EXAMPLE: { EXAMPLE },
@@ -9,20 +8,12 @@ const {
 export const seedExampleDatabase = async () => {
   await sqlConnection(FOO.TABLE).insert({
     [FOO.COLUMNS.FOO_ID]: 1,
-    [FOO.COLUMNS.EXTERNAL_ID]: 'any_external_id',
-    [FOO.COLUMNS.CREATED_AT]: new Date(),
-    [FOO.COLUMNS.UPDATED_AT]: sumDays(new Date(), 1), // tomorrow!
-    [FOO.COLUMNS.DELETED_AT]: null,
     [FOO.COLUMNS.EXAMPLE_ID]: 1,
     [FOO.COLUMNS.VALUE]: 100
   });
 
   await sqlConnection(EXAMPLE.TABLE).insert({
     [EXAMPLE.COLUMNS.EXAMPLE_ID]: 1,
-    [EXAMPLE.COLUMNS.EXTERNAL_ID]: 'any_external_id',
-    [EXAMPLE.COLUMNS.CREATED_AT]: new Date(),
-    [EXAMPLE.COLUMNS.UPDATED_AT]: sumDays(new Date(), 1), // tomorrow!
-    [EXAMPLE.COLUMNS.DELETED_AT]: null,
     [EXAMPLE.COLUMNS.VALUE]: 100
   });
 };


### PR DESCRIPTION
#### Description
This pull request fixes a bug catched by @malu-ribeiro.

The bug occurred in the createMockTable and tryToRun functions within the database migrations. When setting a default value for a column, these functions previously failed to correctly resolve the internal Promise responsible for setting the value.

#### What type of PR contains? 

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🔥 Performance Improvements
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert

#### Related Tickets & Documents
This pull request closes the following issues:
Fixes #26 