### PR TITLE
Fix State between hook and handler

### DIFF
--- a/src/@types/fastify.d.ts
+++ b/src/@types/fastify.d.ts
@@ -1,0 +1,7 @@
+import type { SharedState } from '@/presentation/protocols/shared-state';
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    state: Partial<SharedState>;
+  }
+}

--- a/src/@types/fastify.d.ts
+++ b/src/@types/fastify.d.ts
@@ -1,7 +1,8 @@
+import type { STATE_KEY } from '@/infra/http/utils/http-server/types';
 import type { SharedState } from '@/presentation/protocols/shared-state';
 
 declare module 'fastify' {
   interface FastifyRequest {
-    state: Partial<SharedState>;
+    [STATE_KEY]: Partial<SharedState>;
   }
 }

--- a/src/infra/http/utils/http-server/http-server.ts
+++ b/src/infra/http/utils/http-server/http-server.ts
@@ -57,7 +57,7 @@ export class HttpServer {
   }
 
   private initializeStateInRequest() {
-    this.fastify.decorateRequest('state');
+    this.fastify.decorateRequest(STATE_KEY);
   }
 
   public use(
@@ -392,8 +392,8 @@ export class HttpServer {
   ): RouteHandlerMethod {
     return async (request, reply) => {
       try {
-        if (!request.state) {
-          request.state = {};
+        if (!request[STATE_KEY]) {
+          request[STATE_KEY] = {};
         }
 
         request.body = convertSnakeCaseKeysToCamelCase(request.body);
@@ -402,7 +402,7 @@ export class HttpServer {
 
         await makeFlow({
           [REQUEST_KEY]: request,
-          [STATE_KEY]: request.state,
+          [STATE_KEY]: request[STATE_KEY],
           [REPLY_KEY]: reply
         })(...this.adaptMiddlewares(middlewares))();
       } catch (error) {
@@ -414,8 +414,8 @@ export class HttpServer {
   private adapterWithFlow(middlewares: RouteMiddleware[]): RouteHandlerMethod {
     return async (request, reply) => {
       try {
-        if (!request.state) {
-          request.state = {};
+        if (!request[STATE_KEY]) {
+          request[STATE_KEY] = {};
         }
 
         request.body = convertSnakeCaseKeysToCamelCase(request.body);
@@ -424,7 +424,7 @@ export class HttpServer {
 
         await makeFlow({
           [REQUEST_KEY]: request,
-          [STATE_KEY]: request.state,
+          [STATE_KEY]: request[STATE_KEY],
           [REPLY_KEY]: reply
         })(...this.adaptMiddlewares(middlewares))();
 

--- a/test/e2e/mocks/routes/mock.ts
+++ b/test/e2e/mocks/routes/mock.ts
@@ -1,10 +1,10 @@
 import { Route } from '@/infra/http/utils';
 
 export default function (route: Route) {
-  route.get('/mock', (req, reply) => {
+  route.get('/mock', (req, reply, next, [{ message }]) => {
     reply.send({
       statusCode: 200,
-      message: 'works!'
+      message
     });
   });
 }

--- a/test/e2e/route-directory-implementations.spec.ts
+++ b/test/e2e/route-directory-implementations.spec.ts
@@ -22,8 +22,7 @@ describe('Route Directory Implementations', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toStrictEqual({
-        statusCode: 200,
-        message: 'works!'
+        statusCode: 200
       });
     });
   });
@@ -53,8 +52,7 @@ describe('Route Directory Implementations', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toStrictEqual({
-        statusCode: 200,
-        message: 'works!'
+        statusCode: 200
       });
     });
   });
@@ -62,7 +60,7 @@ describe('Route Directory Implementations', () => {
     const application = new HttpServer(fastify);
     application.setBaseUrl('/api/v1');
 
-    const hookMock = jest.fn().mockImplementation((req, res, next) => {
+    const hookMock = jest.fn().mockImplementation((req, res, next, state) => {
       next();
     });
     const getServer = () => application.getServer();
@@ -87,8 +85,7 @@ describe('Route Directory Implementations', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toStrictEqual({
-        statusCode: 200,
-        message: 'works!'
+        statusCode: 200
       });
       expect(hookMock).toHaveBeenCalled();
       expect(hookMock).toHaveBeenCalledTimes(1);
@@ -119,8 +116,7 @@ describe('Route Directory Implementations', () => {
 
       expect(response.statusCode).toBe(200);
       expect(response.body).toStrictEqual({
-        statusCode: 200,
-        message: 'works!'
+        statusCode: 200
       });
       expect(hookMock).toHaveBeenCalled();
       expect(hookMock).toHaveBeenCalledTimes(1);
@@ -131,9 +127,15 @@ describe('Route Directory Implementations', () => {
     const application = new HttpServer(fastify);
     application.setBaseUrl('/api/v1');
 
-    const hookMock = jest.fn().mockImplementation((req, res, next) => {
-      next();
-    });
+    const hookMock = jest
+      .fn()
+      .mockImplementation((req, res, next, [_state, setState]) => {
+        setState({
+          message: 'works!'
+        });
+        next();
+      });
+
     const getServer = () => application.getServer();
 
     afterAll(() => {


### PR DESCRIPTION
#### Description
This pull request fixes a bug catched by @d4visoares, the hooks are not sharing the statehook with the handler

To fix this bug, we shared the state object in the request object of fastify and passing only the references to the adapters

#### What type of PR contains? 

- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🔥 Performance Improvements
- [x] 🧑‍💻 Code Refactor
- [x] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert
