### PR TITLE
hotfix(web-server): loading state management to WebServer route implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2024-11-26
+
+### Fixed
+
+- Fixing the route loading management, add a mechanism to track loading state of WebServer class
+
 ## [2.1.1] - 2024-11-19
 
 ### Fixed

--- a/TEMPLATE-CHANGELOG.md
+++ b/TEMPLATE-CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2024-11-26
+
+### Fixed
+
+- Fixing the route loading management, add a mechanism to track loading state of WebServer class
+
 ## [2.1.1] - 2024-11-19
 
 ### Fixed


### PR DESCRIPTION
#### Description
This pull request introduces a mechanism to ensure that all routes are loaded before the web server starts accepting requests. The key changes include the addition of a new flag to track route loading status and the implementation of a check to wait until all routes are loaded.

#### What type of PR contains? 
- [ ] 🍕 Feature
- [x] 🐛 Bug Fix
- [ ] 📝 Documentation Update
- [ ] 🔥 Performance Improvements
- [x] 🧑‍💻 Code Refactor
- [ ] ✅ Test
- [ ] 🤖 Build
- [ ] 🔁 CI
- [ ] 📦 Chore (Release)
- [ ] ⏩ Revert