### PR TITLE
Change: add content-type parsers for JSON and x-www-form-urlencoded

### DIFF
--- a/TEMPLATE-CHANGELOG.md
+++ b/TEMPLATE-CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.4.1] - 2025-08-19
+
+### Changed
+
+- Add content-type parsers for JSON and x-www-form-urlencoded.
+
 ## [2.4.0] - 2025-05-08
 
 ### Added

--- a/src/infra/http/util/web-server/web-server.ts
+++ b/src/infra/http/util/web-server/web-server.ts
@@ -90,6 +90,32 @@ export class WebServer {
       this.connections.add(socket);
       socket.on('close', () => this.connections.delete(socket));
     });
+
+    fastify.addContentTypeParser(
+      'application/json',
+      { parseAs: 'string' },
+      function (_req, body, done) {
+        if (!body) return done(null, {});
+        try {
+          done(null, JSON.parse(String(body)));
+        } catch (error) {
+          done(error as Error, undefined);
+        }
+      }
+    );
+
+    fastify.addContentTypeParser(
+      'application/x-www-form-urlencoded',
+      { parseAs: 'string' },
+      function (_req, body, done) {
+        try {
+          const parsed = Object.fromEntries(new URLSearchParams(String(body)));
+          done(null, parsed);
+        } catch (error) {
+          done(error as Error, undefined);
+        }
+      }
+    );
   }
 
   public getWebsocketServer = () => this.socketIO;


### PR DESCRIPTION
### Description

This PR adds **content-type parsers** to the `WebServer` to handle different request formats.

* Added support for `application/json` with fallback to `{}` when the body is empty.
* Added support for `application/x-www-form-urlencoded`.

### Motivation

Previously, requests with `application/x-www-form-urlencoded` returned **415 Unsupported Media Type**.
With this change, the server can now correctly parse and process this payload type.