### PR TITLE
fix: connect to the configured RabbitMQ vhost

### DIFF
--- a/src/main/util/get-rabbitmq-connection.ts
+++ b/src/main/util/get-rabbitmq-connection.ts
@@ -9,7 +9,8 @@ export function getRabbitmqConnection() {
       user: RABBIT.USER,
       password: RABBIT.PASSWORD,
       host: RABBIT.HOST,
-      port: RABBIT.PORT
+      port: RABBIT.PORT,
+      virtualHost: RABBIT.VIRTUAL_HOST
     })
     .start();
 }


### PR DESCRIPTION
## Description

This fix passes `virtualHost` to `setCredentials` so the RabbitMQ connection is opened on the vhost configured via `RABBIT_VIRTUAL_HOST`, instead of always falling back to the default vhost (`/`).

What type of PR contains?

- [ ] 🍕 Feature
- [x]  🐛 Bug Fix
- [ ]  📝 Documentation Update
- [ ]  🔥 Performance Improvements
- [ ]  🧑‍💻 Code Refactor
- [ ]  ✅ Test
- [ ]  🤖 Build
- [ ]  🔁 CI
- [ ]  📦 Chore (Release)
- [ ]  ⏩ Revert

This pull request closes the following issues:
Fixes https://github.com/lucassm02/nodejs-template/issues/62